### PR TITLE
No builds, no dir fix

### DIFF
--- a/stage3/stage3.sh
+++ b/stage3/stage3.sh
@@ -23,7 +23,7 @@ checkRootUser
 requireTools "mknod"
 
 prefetchSources
-
+mkdir ${SERPENT_BUILD_DIR} #No builds yet, no dir yet.
 bringUpMounts
 
 for component in ${COMPONENTS[@]} ; do
@@ -31,3 +31,4 @@ for component in ${COMPONENTS[@]} ; do
 done
 
 takeDownMounts
+


### PR DESCRIPTION
Since we never build anything before mounting in stage3, build/stage3 does not
exists and stage3 fails. This fixes that.